### PR TITLE
Implement ChMaskCntl = 5 for LinkADRReq commands

### DIFF
--- a/src/mac/region/channel_plan/dynamic.rs
+++ b/src/mac/region/channel_plan/dynamic.rs
@@ -151,11 +151,14 @@ where
                 }
                 Ok(())
             }
-            // ???
             5 => {
-                for i in 0..9 {
-                    let index = i + (channel_mask_ctrl * 16) as usize;
-                    new_mask[index] = channel_mask.is_enabled(i).unwrap()
+                let channel_mask_be: u16 =
+                    channel_mask.get_index(0) as u16 | ((channel_mask.get_index(1) as u16) << 8);
+                for i in 0..NUM_OF_CHANNEL_BLOCKS {
+                    let is_channel_block_enabled = channel_mask_be & (1 << i) != 0;
+                    for j in 0..NUM_OF_CHANNELS_IN_BLOCK {
+                        new_mask[(i * NUM_OF_CHANNELS_IN_BLOCK) + j] = is_channel_block_enabled;
+                    }
                 }
                 Ok(())
             }

--- a/src/mac/region/channel_plan/fixed.rs
+++ b/src/mac/region/channel_plan/fixed.rs
@@ -139,11 +139,17 @@ where
                 }
                 Ok(())
             }
-            // ???
             5 => {
-                for i in 0..9 {
-                    let index = i + (channel_mask_ctrl * 16) as usize;
-                    new_mask[index] = channel_mask.is_enabled(i).unwrap()
+                // This algorithm does not implement the modification of single 500 KHz channels
+                // for bits 0 through 7, since processing of bit 8 affects the entire 500 KHz channel block.
+                // Until further evidence, the regional specification for fixed channels is taken to need clarification.
+                let channel_mask_be: u16 =
+                    channel_mask.get_index(0) as u16 | ((channel_mask.get_index(1) as u16) << 8);
+                for i in 0..NUM_OF_CHANNEL_BLOCKS {
+                    let is_channel_block_enabled = channel_mask_be & (1 << i) != 0;
+                    for j in 0..NUM_OF_CHANNELS_IN_BLOCK {
+                        new_mask[(i * NUM_OF_CHANNELS_IN_BLOCK) + j] = is_channel_block_enabled;
+                    }
                 }
                 Ok(())
             }


### PR DESCRIPTION
Implement ChMaskCntl = 5 for LinkADRReq commands, setting blocks of 8 channels on or off depending on the channel mask provided.