### PR TITLE
First documentation pass

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,31 @@
+name: CI
+env:
+  CI: true
+on:
+  push:
+    # Run on the main branch
+    branches:
+      - main
+    # Releases are tags named 'v<version>', and must have the "major.minor.micro", for example: "0.1.0".
+    # Release candidates are tagged as `v<version>-rc<num>`, for example: "0.1.0-rc1".
+    tags:
+      - "v*"
+  # Also on PRs, just be careful not to publish anything
+  pull_request:
+
+
+jobs:
+  ci:
+
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build
+        run: cargo check
+
+      - name: Clippy
+        run: cargo clippy
+
+      - name: Test
+        run: cargo test

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,11 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"rust-lang.rust-analyzer",
+		"tamasfe.even-better-toml",
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": []
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
   "editor.formatOnSave": true,
+  "[toml]": {
+    "editor.formatOnSave": false
+  },
   "rust-analyzer.check.allTargets": true,
   "rust-analyzer.procMacro.enable": true,
   "rust-analyzer.imports.granularity.enforce": true,
@@ -7,5 +10,6 @@
   "rust-analyzer.cargo.buildScripts.enable": true,
   "rust-analyzer.procMacro.attributes.enable": false,
   "rust-analyzer.cargo.features": "all",
-  "rust-analyzer.check.features": "all"
+  "rust-analyzer.check.features": "all",
+  "rust-analyzer.check.command": "clippy"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# LoRaWAN 1.0.4 Class A
+
+[![CI](https://github.com/lucasgranberg/lorawan/actions/workflows/ci.yaml/badge.svg)](https://github.com/lucasgranberg/lorawan/actions/workflows/ci.yaml)
+
+## Why?
+
+## Chat
+
+A public chat on LoRa/LoRaWAN topics using Rust is here:
+
+- <a href="https://matrix.to/#/#public-lora-wan-rs:matrix.org">Matrix room</a>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/lucasgranberg/lorawan/actions/workflows/ci.yaml/badge.svg)](https://github.com/lucasgranberg/lorawan/actions/workflows/ci.yaml)
 
-## Why?
+## To be provided
 
 ## Chat
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,5 @@
 # Before upgrading check that everything is available on all tier1 targets here:
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
-channel = "nightly-2023-04-11"
-components = ["rust-src", "rustfmt", "llvm-tools-preview"]
-targets = ["thumbv7em-none-eabi"]
+channel = "nightly-2023-06-28"
+components = ["rust-src", "rustfmt", "llvm-tools", "clippy"]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,23 @@
+# This file defines the Rust style for automatic reformatting.
+# See also https://rust-lang.github.io/rustfmt
+
+# Rust language edition.
+edition = "2021"
+
+# Line endings will be converted to \n.
+newline_style = "Unix"
+
+# The "Default" setting has a heuristic which splits lines too aggresively.
+use_small_heuristics = "Max"
+
+# Always put if else statements on multiple lines.
+single_line_if_else_max_width = 0
+
+# Version of the formatting rules to use.
+# version = "Two"
+
+# Max width of comments before wrapping.
+# comment_width = 100
+
+# Wrap comments above comment_width.
+# wrap_comments = true

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -36,10 +36,15 @@ where
     }
 }
 pub trait Device {
+    /// Timer provided by the calling code.
     type Timer: Timer;
+    /// Radio provided by the calling code.
     type Radio: Radio;
+    /// Random number generator provided by calling code.
     type Rng: Rng;
+    /// Storage capability provided by calling code.
     type NonVolatileStore: NonVolatileStore;
+
     fn timer(&mut self) -> &mut Self::Timer;
     fn radio(&mut self) -> &mut Self::Radio;
     fn rng(&mut self) -> &mut Self::Rng;

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -47,22 +47,29 @@ pub trait Device {
     /// Storage capability provided by calling code.
     type NonVolatileStore: NonVolatileStore;
 
+    /// Get the caller-supplied timer implementation.
     fn timer(&mut self) -> &mut Self::Timer;
+    /// Get the caller-supplied LoRa radio implementation.
     fn radio(&mut self) -> &mut Self::Radio;
+    /// Get the caller-supllied random number generator implementation.
     fn rng(&mut self) -> &mut Self::Rng;
+    /// Get the caller-supplied persistence implementation.
     fn non_volatile_store(&mut self) -> &mut Self::NonVolatileStore;
+    /// Get the caller-supplied maximum EIRP.
     fn max_eirp() -> u8;
+    /// Process the DeviceTimeAns response from a network server as directed by the caller.
     fn handle_device_time(&mut self, _seconds: u32, _nano_seconds: u32) {
         // default do nothing
     }
+    /// Process the LinkCheckAns response from a network server as directed by the caller.
     fn handle_link_check(&mut self, _gateway_count: u8, _margin: u8) {
         // default do nothing
     }
-
+    /// Process the LinkADRReq request from a network server as directed by the caller.
     fn adaptive_data_rate_enabled(&self) -> bool {
         true
     }
-
+    /// Create a DevStatusAns response to a network server specifying battery level as directed by the caller.
     fn battery_level(&self) -> Option<f32> {
         None
     }
@@ -70,15 +77,19 @@ pub trait Device {
 
 /// Specification of end device-specific limits provided by the caller.
 pub trait DeviceSpecs {
+    /// Get the minimum frequency supported by a device as indicated by the caller.
     fn min_frequency() -> Option<u32> {
         None
     }
+    /// Get the maximum frequency supported by a device as indicated by the caller.
     fn max_frequency() -> Option<u32> {
         None
     }
+    /// Get the minimum DR supported by a device as indicated by the caller.
     fn min_data_rate() -> Option<DR> {
         None
     }
+    /// Get the maximum DR supported by a device as indicated by the caller.
     fn max_data_rate() -> Option<DR> {
         None
     }

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -35,6 +35,8 @@ where
         Self::Device(value)
     }
 }
+
+/// Specification of end device-specific functionality provided by the caller.
 pub trait Device {
     /// Timer provided by the calling code.
     type Timer: Timer;
@@ -66,6 +68,7 @@ pub trait Device {
     }
 }
 
+/// Specification of end device-specific limits provided by the caller.
 pub trait DeviceSpecs {
     fn min_frequency() -> Option<u32> {
         None

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -1,3 +1,5 @@
+//! Wrapper for all necessary functionality implemented by calling code.
+
 pub mod non_volatile_store;
 pub mod radio;
 pub mod radio_buffer;
@@ -14,6 +16,7 @@ use self::non_volatile_store::NonVolatileStore;
 
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[allow(missing_docs)]
 pub enum Error<D>
 where
     D: Device,

--- a/src/device/non_volatile_store.rs
+++ b/src/device/non_volatile_store.rs
@@ -1,3 +1,5 @@
+//! Storage capability supporting persistence during power-off which must be implemented by calling code.
+
 use core::fmt::Debug;
 
 pub trait NonVolatileStore {

--- a/src/device/non_volatile_store.rs
+++ b/src/device/non_volatile_store.rs
@@ -2,6 +2,7 @@
 
 use core::fmt::Debug;
 
+/// Specification of the functionality required of the caller for persistence.
 pub trait NonVolatileStore {
     /// Possible result error.
     #[cfg(feature = "defmt")]

--- a/src/device/non_volatile_store.rs
+++ b/src/device/non_volatile_store.rs
@@ -11,10 +11,11 @@ pub trait NonVolatileStore {
     #[cfg(not(feature = "defmt"))]
     type Error: Debug;
 
+    /// Persist data which can be converted to a u8 array.
     fn save<'a, T>(&mut self, item: T) -> Result<(), Self::Error>
     where
         T: Sized + Into<&'a [u8]>;
-
+    /// Retrieve data from persistence which can be converted from a u8 array.
     fn load<'a, T>(&'a mut self) -> Result<T, Self::Error>
     where
         T: Sized + TryFrom<&'a [u8]>;

--- a/src/device/non_volatile_store.rs
+++ b/src/device/non_volatile_store.rs
@@ -3,6 +3,7 @@
 use core::fmt::Debug;
 
 pub trait NonVolatileStore {
+    /// Possible result error.
     #[cfg(feature = "defmt")]
     type Error: Debug + defmt::Format;
 

--- a/src/device/radio/mod.rs
+++ b/src/device/radio/mod.rs
@@ -1,11 +1,10 @@
+//! LoRa radio functionality which must be implemented by calling code.
+
 pub mod types;
 use core::fmt::Debug;
 use types::*;
 
-/// An asynchronous timer that allows the state machine to await
-/// between RX windows.
-
-/// An asynchronous radio implementation that can transmit and receive data.
+/// An asynchronous radio implementation that can transmit and receive data and sleep when unneeded.
 pub trait Radio: Sized {
     #[cfg(feature = "defmt")]
     type Error: Debug + defmt::Format;

--- a/src/device/radio/mod.rs
+++ b/src/device/radio/mod.rs
@@ -16,7 +16,6 @@ pub trait Radio: Sized {
     /// Transmit data buffer with the given tranciever configuration. The returned future
     /// should only complete once data have been transmitted.
     async fn tx(&mut self, config: TxConfig, buf: &[u8]) -> Result<usize, Self::Error>;
-
     /// Receive data into the provided buffer with the given tranceiver configuration. The returned future
     /// should only complete when RX data have been received or a timeout has occurred.
     async fn rx(
@@ -25,7 +24,6 @@ pub trait Radio: Sized {
         window_in_secs: u8,
         rx_buf: &mut [u8],
     ) -> Result<(usize, RxQuality), Self::Error>;
-
     /// Place the radio in sleep mode with warm or cold start specified.
     async fn sleep(&mut self, warm_start: bool) -> Result<(), Self::Error>;
 }

--- a/src/device/radio/mod.rs
+++ b/src/device/radio/mod.rs
@@ -17,7 +17,7 @@ pub trait Radio: Sized {
     /// should only complete once data have been transmitted.
     async fn tx(&mut self, config: TxConfig, buf: &[u8]) -> Result<usize, Self::Error>;
 
-    /// Receive data into the provided buffer with the given tranciever configuration. The returned future
+    /// Receive data into the provided buffer with the given tranceiver configuration. The returned future
     /// should only complete when RX data have been received or a timeout has occurred.
     async fn rx(
         &mut self,

--- a/src/device/radio/mod.rs
+++ b/src/device/radio/mod.rs
@@ -6,6 +6,7 @@ use types::*;
 
 /// An asynchronous radio implementation that can transmit and receive data and sleep when unneeded.
 pub trait Radio: Sized {
+    /// Possible result error.
     #[cfg(feature = "defmt")]
     type Error: Debug + defmt::Format;
 

--- a/src/device/radio/types.rs
+++ b/src/device/radio/types.rs
@@ -113,13 +113,17 @@ pub struct RxQuality {
 }
 
 impl RxQuality {
+    /// Creation.
     pub fn new(rssi: i16, snr: i8) -> RxQuality {
         RxQuality { rssi, snr }
     }
 
+    /// Get the RSSI property.
     pub fn rssi(self) -> i16 {
         self.rssi
     }
+
+    /// Get the SNR property.
     pub fn snr(self) -> i8 {
         self.snr
     }

--- a/src/device/radio/types.rs
+++ b/src/device/radio/types.rs
@@ -1,7 +1,10 @@
+//! Types used to control communication with the LoRa physical layer.
+
 use lora_phy;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone)]
+#[allow(missing_docs)]
 pub enum Bandwidth {
     _125KHz,
     _250KHz,
@@ -21,6 +24,7 @@ impl From<Bandwidth> for lora_phy::mod_params::Bandwidth {
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone)]
+#[allow(missing_docs)]
 pub enum SpreadingFactor {
     _7,
     _8,
@@ -46,6 +50,7 @@ impl From<SpreadingFactor> for lora_phy::mod_params::SpreadingFactor {
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone)]
+#[allow(missing_docs)]
 pub enum CodingRate {
     _4_5,
     _4_6,

--- a/src/device/radio/types.rs
+++ b/src/device/radio/types.rs
@@ -70,30 +70,45 @@ impl From<CodingRate> for lora_phy::mod_params::CodingRate {
     }
 }
 
+/// LoRaWAN radio signal configuration.
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug)]
 pub struct RfConfig {
+    /// Frequency in Hz.
     pub frequency: u32,
+    /// Coding rate (ratio of actual data bits to error-correcting data bits).
     pub coding_rate: CodingRate,
+    /// Data rate (bandwidth and spreading factor).
     pub data_rate: Datarate,
 }
+
+/// LoRaWAN data rate.
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone)]
 pub struct Datarate {
+    /// Bandwidth.
     pub bandwidth: Bandwidth,
+    /// Spreading factor.
     pub spreading_factor: SpreadingFactor,
 }
+
+/// LoRaWAN packet transmission configuration.
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug)]
 pub struct TxConfig {
+    /// Power.
     pub pw: u8,
+    /// Radio signal configuration.
     pub rf: RfConfig,
 }
 
+/// LoRaWAN packet reception quality.
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone, Copy)]
 pub struct RxQuality {
+    /// Received signal strength indication.
     pub rssi: i16,
+    /// Signal-to-noise ratio.
     pub snr: i8,
 }
 

--- a/src/device/radio_buffer.rs
+++ b/src/device/radio_buffer.rs
@@ -1,5 +1,8 @@
+//! Buffer functionality for send/receive data tranmission between the caller and the LoRa physical layer.
+
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[allow(missing_docs)]
 pub enum Error {
     BufferFull,
 }
@@ -11,19 +14,13 @@ pub struct RadioBuffer<const N: usize> {
 }
 impl<const N: usize> Default for RadioBuffer<N> {
     fn default() -> Self {
-        Self {
-            packet: [0; N],
-            pos: Default::default(),
-        }
+        Self { packet: [0; N], pos: Default::default() }
     }
 }
 
 impl<const N: usize> RadioBuffer<N> {
     pub fn new() -> Self {
-        Self {
-            packet: [0; N],
-            pos: 0,
-        }
+        Self { packet: [0; N], pos: 0 }
     }
 
     pub fn clear(&mut self) {

--- a/src/device/radio_buffer.rs
+++ b/src/device/radio_buffer.rs
@@ -7,6 +7,7 @@ pub enum Error {
     BufferFull,
 }
 
+/// Packet buffer used to send/receive data.
 #[derive(Clone)]
 pub struct RadioBuffer<const N: usize> {
     packet: [u8; N],

--- a/src/device/radio_buffer.rs
+++ b/src/device/radio_buffer.rs
@@ -20,14 +20,17 @@ impl<const N: usize> Default for RadioBuffer<N> {
 }
 
 impl<const N: usize> RadioBuffer<N> {
+    /// Creation.
     pub fn new() -> Self {
         Self { packet: [0; N], pos: 0 }
     }
 
+    /// Mark as empty.
     pub fn clear(&mut self) {
         self.pos = 0;
     }
 
+    /// Add data as long as it fits within the buffer.
     pub fn extend_from_slice(&mut self, buf: &[u8]) -> Result<(), Error> {
         if self.pos + buf.len() < self.packet.len() {
             self.packet[self.pos..self.pos + buf.len()].copy_from_slice(buf);
@@ -38,10 +41,12 @@ impl<const N: usize> RadioBuffer<N> {
         }
     }
 
+    /// Provide the mutable buffer without regard to contained data.
     pub fn as_raw_slice(&mut self) -> &mut [u8] {
         &mut self.packet
     }
 
+    /// Update the start position for subsequent data additions.
     pub fn inc(&mut self, len: usize) {
         assert!(self.pos + len < self.packet.len());
         self.pos += len;

--- a/src/device/rng.rs
+++ b/src/device/rng.rs
@@ -11,5 +11,6 @@ pub trait Rng {
     #[cfg(not(feature = "defmt"))]
     type Error: Debug;
 
+    /// Get the next random number.
     fn next_u32(&mut self) -> Result<u32, Self::Error>;
 }

--- a/src/device/rng.rs
+++ b/src/device/rng.rs
@@ -2,6 +2,7 @@
 
 use core::fmt::Debug;
 pub trait Rng {
+    /// Possible result error.
     #[cfg(feature = "defmt")]
     type Error: Debug + defmt::Format;
 

--- a/src/device/rng.rs
+++ b/src/device/rng.rs
@@ -1,3 +1,5 @@
+//! Random number generation functionality which must be implemented by calling code.
+
 use core::fmt::Debug;
 pub trait Rng {
     #[cfg(feature = "defmt")]

--- a/src/device/rng.rs
+++ b/src/device/rng.rs
@@ -1,6 +1,8 @@
 //! Random number generation functionality which must be implemented by calling code.
 
 use core::fmt::Debug;
+
+/// Specification of the functionality required of the caller for random number generation.
 pub trait Rng {
     /// Possible result error.
     #[cfg(feature = "defmt")]

--- a/src/device/timer.rs
+++ b/src/device/timer.rs
@@ -1,5 +1,9 @@
+//! Timer functionality which must be implemented by calling code.
+
 use core::{fmt::Debug, future::Future};
 
+/// An asynchronous timer that allows the state machine to await
+/// between RX windows.
 pub trait Timer: Sized {
     #[cfg(feature = "defmt")]
     type Error: Debug + defmt::Format;

--- a/src/device/timer.rs
+++ b/src/device/timer.rs
@@ -5,6 +5,7 @@ use core::{fmt::Debug, future::Future};
 /// An asynchronous timer that allows the state machine to await
 /// between RX windows.
 pub trait Timer: Sized {
+    /// Possible result error.
     #[cfg(feature = "defmt")]
     type Error: Debug + defmt::Format;
 
@@ -12,6 +13,7 @@ pub trait Timer: Sized {
     type Error: Debug;
     fn reset(&mut self);
 
+    /// Notification of reaching a time point.
     type AtFuture<'m>: Future<Output = ()> + 'm
     where
         Self: 'm;

--- a/src/device/timer.rs
+++ b/src/device/timer.rs
@@ -5,18 +5,18 @@ use core::{fmt::Debug, future::Future};
 /// An asynchronous timer that allows the state machine to await
 /// between RX windows.
 pub trait Timer: Sized {
-    /// Possible result error.
-    #[cfg(feature = "defmt")]
-    type Error: Debug + defmt::Format;
-
-    #[cfg(not(feature = "defmt"))]
-    type Error: Debug;
-    fn reset(&mut self);
-
     /// Notification of reaching a time point.
     type AtFuture<'m>: Future<Output = ()> + 'm
     where
         Self: 'm;
+    /// Possible result error.
+    #[cfg(feature = "defmt")]
+    type Error: Debug + defmt::Format;
+    #[cfg(not(feature = "defmt"))]
+    type Error: Debug;
 
+    /// Reset the timer.
+    fn reset(&mut self);
+    /// Set the timer to notify in the future.
     fn at<'a>(&self, millis: u64) -> Result<Self::AtFuture<'a>, Self::Error>;
 }

--- a/src/encoding/default_crypto.rs
+++ b/src/encoding/default_crypto.rs
@@ -21,6 +21,7 @@ use super::parser::{
 };
 use super::Error;
 
+/// Cipher-based message authentication code (CMAC) processor.
 pub type Cmac = cmac::Cmac<Aes128>;
 
 /// Provides a default implementation for build object for using the crypto functions.

--- a/src/encoding/default_crypto.rs
+++ b/src/encoding/default_crypto.rs
@@ -5,6 +5,9 @@
 // copied, modified, or distributed except according to those terms.
 //
 // author: Ivaylo Petrov <ivajloip@gmail.com>
+
+//! Default encryption/decryption facility.
+
 use aes::cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
 use aes::Aes128;
 use generic_array::typenum::U16;

--- a/src/encoding/keys.rs
+++ b/src/encoding/keys.rs
@@ -54,8 +54,11 @@ pub trait Cmac {
 ///
 /// This trait provides a way to pick a different implementation of the crypto primitives.
 pub trait CryptoFactory {
+    /// Encrypter type.
     type E: Encrypter;
+    /// Decrypter type.
     type D: Decrypter;
+    /// MAC calculator type.
     type M: Cmac;
 
     /// Method that creates an Encrypter.

--- a/src/encoding/keys.rs
+++ b/src/encoding/keys.rs
@@ -5,6 +5,9 @@
 // copied, modified, or distributed except according to those terms.
 //
 // author: Ivaylo Petrov <ivajloip@gmail.com>
+
+//! Specification of the encryption/decryption features for keys used by LoRaWAN packets.
+
 use super::securityhelpers::generic_array::{typenum::U16, GenericArray};
 
 /// AES128 represents 128 bit AES key.

--- a/src/encoding/keys.rs
+++ b/src/encoding/keys.rs
@@ -35,18 +35,23 @@ impl From<[u8; 4]> for MIC {
 
 /// Trait for implementations of AES128 encryption.
 pub trait Encrypter {
+    /// Encrypt a data block.
     fn encrypt_block(&self, block: &mut GenericArray<u8, U16>);
 }
 
 /// Trait for implementations of AES128 decryption.
 pub trait Decrypter {
+    /// Decrypt a data block.
     fn decrypt_block(&self, block: &mut GenericArray<u8, U16>);
 }
 
-/// Trait for implementations of CMAC.
+/// Trait for implementations of cipher-based message authentication code (CMAC).
 pub trait Cmac {
+    /// Update the data to be processed.
     fn input(&mut self, data: &[u8]);
+    /// Clear the data to be processed.
     fn reset(&mut self);
+    /// Process the data.
     fn result(self) -> GenericArray<u8, U16>;
 }
 

--- a/src/encoding/maccommandcreator.rs
+++ b/src/encoding/maccommandcreator.rs
@@ -721,6 +721,8 @@ pub struct RXTimingSetupAnsCreator {}
 
 impl_mac_cmd_creator_boilerplate!(RXTimingSetupAnsCreator, 0x08);
 
+/// Create a request to set the maximum allowed dwell time and
+/// maximum effective isotropic radiated power (EIRP).
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct TXParamSetupReqCreator {
@@ -749,11 +751,15 @@ impl TXParamSetupReqCreator {
     }
 }
 
+/// Create a response to a network server which set the maximum allowed dwell time
+/// and maximum effective isotropic radiated power (EIRP) using TXParamSetupReq.
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct TXParamSetupAnsCreator;
 impl_mac_cmd_creator_boilerplate!(TXParamSetupAnsCreator, 0x09);
 
+/// Create a request to modify the definition of a downlink RX1 channel by shifting the downlink
+/// frequency from the uplink frequency.
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DlChannelReqCreator {
@@ -772,6 +778,9 @@ impl DlChannelReqCreator {
         self
     }
 }
+
+/// Create a response to a network server which modified the definition of a downlink RX1 channel
+/// by shifting the downlink frequency from the uplink frequency using DlChannelReq.
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DlChannelAnsCreator {
@@ -803,10 +812,15 @@ impl DlChannelAnsCreator {
         self
     }
 }
+
+/// Create a request to a network server for the current network time, expressesd in fractional seconds
+/// since the GPS epoch origin (January 6, 1980 00:00:00 UTC).
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DeviceTimeReqCreator;
 impl_mac_cmd_creator_boilerplate!(DeviceTimeReqCreator, 0x0D);
+
+/// Create a response to a DeviceTimeReq request, providing the current network time,
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DeviceTimeAnsCreator {

--- a/src/encoding/maccommandcreator.rs
+++ b/src/encoding/maccommandcreator.rs
@@ -6,6 +6,8 @@
 //
 // Author: Ivaylo Petrov <ivajloip@gmail.com>
 
+//! Creation functionality for LoRaWAN MAC commands.
+
 use super::Error;
 
 use super::maccommands::*;
@@ -18,7 +20,7 @@ macro_rules! mac_cmds_creator_enum {
         )*
     }
     ) => {
-        #[allow(dead_code)]
+        #[allow(dead_code, missing_docs)]
         #[derive(Debug)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         $outer_vis enum $outer_type$(<$outer_lifetime>)* {

--- a/src/encoding/maccommands.rs
+++ b/src/encoding/maccommands.rs
@@ -10,6 +10,8 @@
 
 use super::Error;
 use core::convert::Infallible;
+
+/// Specification of the functionality which supports serialization of the command identifier and payload for a MAC command.
 pub trait SerializableMacCommand {
     fn payload_bytes(&self) -> &[u8];
     fn cid(&self) -> u8;

--- a/src/encoding/maccommands.rs
+++ b/src/encoding/maccommands.rs
@@ -758,6 +758,8 @@ impl From<u8> for DLSettings {
 //         self.0
 //     }
 // }
+
+/// Basic frequency handling.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Frequency([u8; 3]);
 

--- a/src/encoding/maccommands.rs
+++ b/src/encoding/maccommands.rs
@@ -6,6 +6,8 @@
 //
 // author: Ivaylo Petrov <ivajloip@gmail.com>
 
+//! LoRaWAN MAC command processing features.
+
 use super::Error;
 use core::convert::Infallible;
 pub trait SerializableMacCommand {
@@ -111,7 +113,7 @@ macro_rules! mac_cmds_enum {
     ) => {
         #[derive(Debug, PartialEq)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        #[allow(clippy::len_without_is_empty)]
+        #[allow(clippy::len_without_is_empty, missing_docs)]
         $outer_vis enum $outer_type$(<$outer_lifetime>)* {
             $(
                 $name($type$(<$lifetime>)*),
@@ -409,11 +411,7 @@ pub struct MacCommandIterator<'a, T> {
 
 impl<'a, T> MacCommandIterator<'a, T> {
     pub fn new(data: &'a [u8]) -> Self {
-        Self {
-            data,
-            index: 0,
-            item: Default::default(),
-        }
+        Self { data, index: 0, item: Default::default() }
     }
 }
 
@@ -524,9 +522,7 @@ impl<'de, const N: usize> serde::de::Visitor<'de> for ChannelMaskDeserializer<N>
         let mut index = 0;
         while let Some(el) = seq.next_element()? {
             if index >= N {
-                return Err(serde::de::Error::custom(
-                    "ChannelMask has too many elements",
-                ));
+                return Err(serde::de::Error::custom("ChannelMask has too many elements"));
             } else {
                 arr[index] = el;
                 index += 1;

--- a/src/encoding/mod.rs
+++ b/src/encoding/mod.rs
@@ -6,7 +6,8 @@
 //
 // author: Ivaylo Petrov <ivajloip@gmail.com>
 
-//! This module implements LoRaWAN packet handling and parsing.
+//! LoRaWAN packet handling and parsing.
+
 #![allow(clippy::upper_case_acronyms)]
 
 use crate::device::Device;
@@ -22,6 +23,7 @@ mod securityhelpers;
 
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[allow(missing_docs)]
 pub enum Error {
     OutOfRange,
     BufferTooSmall,

--- a/src/encoding/parser.rs
+++ b/src/encoding/parser.rs
@@ -113,6 +113,7 @@ macro_rules! fixed_len_struct {
 ///
 /// It can either be JoinRequest, JoinAccept, or DataPayload.
 #[derive(Debug, PartialEq, Eq)]
+#[allow(missing_docs)]
 pub enum PhyPayload<T, F> {
     JoinRequest(JoinRequestPayload<T, F>),
     JoinAccept(EncryptedJoinAcceptPayload<T, F>),
@@ -134,6 +135,7 @@ impl<T: AsRef<[u8]>, F> AsRef<[u8]> for PhyPayload<T, F> {
 /// It can either be encrypted for example as a result from the [parse](fn.parse.html)
 /// function or not.
 #[derive(Debug, PartialEq, Eq)]
+#[allow(missing_docs)]
 pub enum JoinAcceptPayload<T, F> {
     Encrypted(EncryptedJoinAcceptPayload<T, F>),
     Decrypted(DecryptedJoinAcceptPayload<T, F>),
@@ -154,6 +156,7 @@ impl<T: AsRef<[u8]>, F> AsPhyPayloadBytes for JoinAcceptPayload<T, F> {
 /// It can either be encrypted for example as a result from the [parse](fn.parse.html)
 /// function or not.
 #[derive(Debug, PartialEq, Eq)]
+#[allow(missing_docs)]
 pub enum DataPayload<T, F> {
     Encrypted(EncryptedDataPayload<T, F>),
     Decrypted(DecryptedDataPayload<T>),
@@ -478,6 +481,7 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>, F: CryptoFactory> DecryptedJoinAcceptPayload<
 
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[allow(missing_docs)]
 pub enum CfList {
     DynamicChannel([Frequency; 5]),
     FixedChannel(ChannelMask<12>),
@@ -567,10 +571,7 @@ pub trait DataHeader {
 
     /// Gives the FHDR of the DataPayload.
     fn fhdr(&self) -> FHDR {
-        FHDR::new_from_raw(
-            &self.as_data_bytes()[1..(1 + self.fhdr_length())],
-            self.is_uplink(),
-        )
+        FHDR::new_from_raw(&self.as_data_bytes()[1..(1 + self.fhdr_length())], self.is_uplink())
     }
 
     /// Gives whether the frame is confirmed
@@ -886,18 +887,18 @@ where
     let bytes = data.as_ref();
     check_phy_data(bytes)?;
     match MHDR(bytes[0]).mtype() {
-        MType::JoinRequest => Ok(PhyPayload::JoinRequest(
-            JoinRequestPayload::new_with_factory(data, factory)?,
-        )),
-        MType::JoinAccept => Ok(PhyPayload::JoinAccept(
-            EncryptedJoinAcceptPayload::new_with_factory(data, factory)?,
-        )),
+        MType::JoinRequest => {
+            Ok(PhyPayload::JoinRequest(JoinRequestPayload::new_with_factory(data, factory)?))
+        }
+        MType::JoinAccept => {
+            Ok(PhyPayload::JoinAccept(EncryptedJoinAcceptPayload::new_with_factory(data, factory)?))
+        }
         MType::UnconfirmedDataUp
         | MType::ConfirmedDataUp
         | MType::UnconfirmedDataDown
-        | MType::ConfirmedDataDown => Ok(PhyPayload::Data(EncryptedDataPayload::new_with_factory(
-            data, factory,
-        )?)),
+        | MType::ConfirmedDataDown => {
+            Ok(PhyPayload::Data(EncryptedDataPayload::new_with_factory(data, factory)?))
+        }
         _ => Err(Error::UnsupportedMessageType),
     }
 }
@@ -961,6 +962,7 @@ impl From<u8> for MHDR {
 
 /// MType gives the possible message types of the PhyPayload.
 #[derive(Debug, PartialEq, Eq)]
+#[allow(missing_docs)]
 pub enum MType {
     JoinRequest,
     JoinAccept,
@@ -974,6 +976,7 @@ pub enum MType {
 
 /// Major gives the supported LoRaWAN payload formats.
 #[derive(Debug, PartialEq, Eq)]
+#[allow(missing_docs)]
 pub enum Major {
     LoRaWANR1,
     RFU,
@@ -1111,6 +1114,7 @@ impl FCtrl {
 /// FRMPayload represents the FRMPayload that can either be the application
 /// data or mac commands.
 #[derive(Debug, PartialEq, Eq)]
+#[allow(missing_docs)]
 pub enum FRMPayload<'a> {
     Data(&'a [u8]),
     MACCommands(FRMMacCommands<'a>),

--- a/src/encoding/securityhelpers.rs
+++ b/src/encoding/securityhelpers.rs
@@ -5,6 +5,9 @@
 // copied, modified, or distributed except according to those terms.
 //
 // author: Ivaylo Petrov <ivajloip@gmail.com>
+
+//! Helpers for key and encryption processing.
+
 use super::keys;
 pub use generic_array;
 use generic_array::GenericArray;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 #![feature(concat_idents)]
 #![feature(async_fn_in_trait)]
 #![allow(incomplete_features)]
+#![warn(missing_docs)]
+#![doc = include_str!("../README.md")]
 
 use core::fmt::Debug;
 mod fmt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod mac;
 
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[allow(missing_docs)]
 pub enum Error<D>
 where
     D: Device,

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -70,6 +70,7 @@ where
     }
 }
 
+/// Specification of end device-specific functionality used by the MAC layer, including that provided by the caller.
 pub trait MacDevice<R, S>: Device
 where
     R: Region,

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -176,6 +176,7 @@ where
     }
 }
 
+/// Composition of properties needed to guide LoRaWAN MAC layer processing.
 pub struct Mac<R, S, C>
 where
     R: Region,

--- a/src/mac/region/channel_plan/dynamic.rs
+++ b/src/mac/region/channel_plan/dynamic.rs
@@ -1,3 +1,5 @@
+//! Dynamic channel plan processing.
+
 use crate::encoding::maccommands::{ChannelMask, DlChannelReqPayload, NewChannelReqPayload};
 use crate::encoding::parser::CfList;
 use crate::mac::region::{Error, Region};
@@ -108,11 +110,7 @@ where
             });
             mask[index] = true;
         }
-        Self {
-            channels,
-            mask: mask,
-            region: Default::default(),
-        }
+        Self { channels, mask, region: Default::default() }
     }
 }
 
@@ -143,7 +141,7 @@ where
                 [None; NUM_OF_CHANNELS_IN_BLOCK];
 
             if (i == 0) && (frame == Frame::Join) {
-                for j in 0..R::default_channels(true) as usize {
+                for j in 0..R::default_channels(true) {
                     available_channel_ids_in_block[count] = Some(j);
                     count += 1;
                 }

--- a/src/mac/region/channel_plan/dynamic.rs
+++ b/src/mac/region/channel_plan/dynamic.rs
@@ -46,6 +46,7 @@ impl<R> DynamicChannelPlan<R>
 where
     R: Region,
 {
+    /// Use a channel ID to obtain a channel from the 800 channel list.
     pub fn get_800_channel(id: usize) -> Result<DynamicChannel, Error> {
         match id {
             0..=34 => {
@@ -85,6 +86,7 @@ where
         }
     }
 
+    /// Use a channel ID to obtain a channel from the 900 channel list.
     pub fn get_900_channel(id: usize) -> Result<DynamicChannel, Error> {
         if id >= MAX_900_CHANNELS {
             return Err(Error::InvalidChannelIndex);

--- a/src/mac/region/channel_plan/dynamic.rs
+++ b/src/mac/region/channel_plan/dynamic.rs
@@ -11,6 +11,7 @@ use super::{
     NUM_OF_CHANNEL_BLOCKS,
 };
 
+/// Composition of properties and functions needed to represent a dynamic channel.
 #[derive(Debug, Clone, Copy)]
 pub struct DynamicChannel {
     pub(crate) ul_frequency: u32,
@@ -30,6 +31,8 @@ impl Channel for DynamicChannel {
         self.ul_data_rate_range
     }
 }
+
+/// Composition of properties and functions needed to control a dynamic channel plan.
 pub struct DynamicChannelPlan<R>
 where
     R: Region,

--- a/src/mac/region/channel_plan/fixed.rs
+++ b/src/mac/region/channel_plan/fixed.rs
@@ -9,6 +9,7 @@ use crate::mac::types::*;
 
 use super::{Channel, ChannelPlan, MAX_CHANNELS, NUM_OF_CHANNELS_IN_BLOCK, NUM_OF_CHANNEL_BLOCKS};
 
+/// Composition of properties and functions needed to represent a fixed channel.
 #[derive(Debug, Clone, Copy)]
 pub struct FixedChannel {
     pub(crate) ul_frequency: u32,
@@ -28,6 +29,8 @@ impl Channel for FixedChannel {
         self.ul_data_rate_range
     }
 }
+
+/// Composition of properties and functions needed to control a fixed channel plan.
 pub struct FixedChannelPlan<R>
 where
     R: Region,

--- a/src/mac/region/channel_plan/fixed.rs
+++ b/src/mac/region/channel_plan/fixed.rs
@@ -1,3 +1,5 @@
+//! Fixed channel plan processing.
+
 use core::marker::PhantomData;
 
 use super::Error;
@@ -50,11 +52,7 @@ where
             });
             mask[index] = true;
         }
-        Self {
-            channels,
-            mask: mask,
-            region: Default::default(),
-        }
+        Self { channels, mask, region: Default::default() }
     }
 }
 
@@ -158,7 +156,7 @@ where
             6 => {
                 new_mask.fill(true);
                 for i in 0..15 {
-                    let index = (i + 64) as usize;
+                    let index = i + 64;
                     new_mask[index] = channel_mask.is_enabled(i).unwrap()
                 }
                 Ok(())
@@ -166,7 +164,7 @@ where
             7 => {
                 new_mask.fill(false);
                 for i in 0..15 {
-                    let index = (i + 64) as usize;
+                    let index = i + 64;
                     new_mask[index] = channel_mask.is_enabled(i).unwrap()
                 }
                 Ok(())

--- a/src/mac/region/channel_plan/mod.rs
+++ b/src/mac/region/channel_plan/mod.rs
@@ -23,7 +23,9 @@ pub trait ChannelPlan<R>
 where
     R: Region,
 {
+    /// Dynamic or fixed channel type.
     type Channel: Channel;
+
     fn get_mut_channel(&mut self, index: usize) -> Option<&mut Option<Self::Channel>>;
     fn get_random_channels_from_blocks(
         &self,

--- a/src/mac/region/channel_plan/mod.rs
+++ b/src/mac/region/channel_plan/mod.rs
@@ -19,11 +19,14 @@ pub const NUM_OF_CHANNEL_BLOCKS: usize = 10;
 /// Number of channels in a channel block.
 pub const NUM_OF_CHANNELS_IN_BLOCK: usize = 8;
 
+/// Specification of basic functionality to get channel properties.
 pub trait Channel {
     fn get_ul_frequency(&self) -> u32;
     fn get_dl_frequency(&self) -> u32;
     fn get_ul_data_rate_range(&self) -> (DR, DR);
 }
+
+/// Specification of functionality to handle a channel plan for a region.
 pub trait ChannelPlan<R>
 where
     R: Region,

--- a/src/mac/region/channel_plan/mod.rs
+++ b/src/mac/region/channel_plan/mod.rs
@@ -8,10 +8,15 @@ pub mod fixed;
 
 use super::{Error, Region};
 
+/// Maximum number of channels in a deployed channel plan.
 pub const MAX_CHANNELS: usize = 80;
+/// Maximum number of configurable channels in an 800 fixed list.
 pub const MAX_800_CHANNELS: usize = 40;
+/// Maximum number of configurable channels in a 900 fixed list.
 pub const MAX_900_CHANNELS: usize = 96;
+/// Number of channel blocks for a channel plan.
 pub const NUM_OF_CHANNEL_BLOCKS: usize = 10;
+/// Number of channels in a channel block.
 pub const NUM_OF_CHANNELS_IN_BLOCK: usize = 8;
 
 pub trait Channel {

--- a/src/mac/region/channel_plan/mod.rs
+++ b/src/mac/region/channel_plan/mod.rs
@@ -21,8 +21,11 @@ pub const NUM_OF_CHANNELS_IN_BLOCK: usize = 8;
 
 /// Specification of basic functionality to get channel properties.
 pub trait Channel {
+    /// Get the uplink frequency.
     fn get_ul_frequency(&self) -> u32;
+    /// Get the downlink frequency.
     fn get_dl_frequency(&self) -> u32;
+    /// Get the uplink data rate range.
     fn get_ul_data_rate_range(&self) -> (DR, DR);
 }
 
@@ -34,23 +37,35 @@ where
     /// Dynamic or fixed channel type.
     type Channel: Channel;
 
+    /// Get a mutable reference to a channel based on channel ID, if the channel exists.
     fn get_mut_channel(&mut self, index: usize) -> Option<&mut Option<Self::Channel>>;
+    /// Get an active channel randomly from each channel block based on the frame type (join or data).  The resulting
+    /// collection may be sparesely populated.
     fn get_random_channels_from_blocks(
         &self,
         channel_block_randoms: [u32; NUM_OF_CHANNEL_BLOCKS],
         frame: Frame,
     ) -> Result<[Option<Self::Channel>; NUM_OF_CHANNEL_BLOCKS], Error>;
+    /// Handle a new channel request from a network server.
     fn handle_new_channel_req(&mut self, payload: NewChannelReqPayload) -> Result<(), Error>;
+    /// Does a channel exist for the given channel ID?
     fn check_uplink_frequency_exists(&self, index: usize) -> bool;
+    /// Create a new channel mask collection based on guidance in the input channel_mask_ctrl and input channel_mask,
+    /// both contained in a LinkADRReq packet from a network server to the end device.
     fn handle_channel_mask(
         &mut self,
         new_mask: &mut [bool; MAX_CHANNELS],
         channel_mask: ChannelMask<2>,
         channel_mask_ctrl: u8,
     ) -> Result<(), Error>;
+    /// Get the current channel mask collection.
     fn get_channel_mask(&self) -> [bool; MAX_CHANNELS];
+    /// Set the current channel maks collection.
     fn set_channel_mask(&mut self, mask: [bool; MAX_CHANNELS]) -> Result<(), Error>;
+    /// Handle a DlChannelReq packet from a network server to the end device.
     fn handle_dl_channel_req(&mut self, payload: DlChannelReqPayload) -> Result<(), Error>;
+    /// Handle the CFList included in a JoinAccept packet from a network server to the end device.
     fn handle_cf_list(&mut self, cf_list: CfList) -> Result<(), Error>;
+    /// Does the uplink frequency exist in the channel plan?
     fn validate_frequency(&self, frequency: u32) -> Result<(), Error>;
 }

--- a/src/mac/region/channel_plan/mod.rs
+++ b/src/mac/region/channel_plan/mod.rs
@@ -1,3 +1,5 @@
+//! Specification of the functionality implemented for dynamic and fixed channel plans.
+
 use crate::encoding::maccommands::{ChannelMask, DlChannelReqPayload, NewChannelReqPayload};
 use crate::encoding::parser::CfList;
 use crate::mac::types::*;

--- a/src/mac/region/eu868/mod.rs
+++ b/src/mac/region/eu868/mod.rs
@@ -7,6 +7,7 @@ use crate::mac::types::{Frame, DR};
 
 const JOIN_CHANNELS: [u32; 3] = [868_100_000, 868_300_000, 868_500_000];
 
+/// Specific processing for the EU868 region.
 pub struct EU868;
 impl crate::mac::Region for EU868 {
     fn default_channels(_is_uplink: bool) -> usize {

--- a/src/mac/region/eu868/mod.rs
+++ b/src/mac/region/eu868/mod.rs
@@ -1,3 +1,5 @@
+//! Processing for the EU868 region, which uses a dynamic channel plan.
+
 use super::channel_plan::dynamic::{DynamicChannel, DynamicChannelPlan};
 use super::Error;
 use crate::device::radio::types::{Bandwidth, CodingRate, Datarate, SpreadingFactor};
@@ -119,7 +121,7 @@ impl crate::mac::Region for EU868 {
             DR::_3 => Ok(dl_dr_matrix[3][rx1_dr_offset as usize]),
             DR::_4 => Ok(dl_dr_matrix[4][rx1_dr_offset as usize]),
             DR::_5 => Ok(dl_dr_matrix[5][rx1_dr_offset as usize]),
-            _ => return Err(super::Error::UnsupportedRx1DROffset(ul_dr, rx1_dr_offset)),
+            _ => Err(super::Error::UnsupportedRx1DROffset(ul_dr, rx1_dr_offset)),
         }
     }
 }

--- a/src/mac/region/mod.rs
+++ b/src/mac/region/mod.rs
@@ -34,40 +34,63 @@ where
 
 /// Specification of functionality to describe regional characteristics.
 pub trait Region {
+    /// Get the number of default uplink or downlink channels for the region.
     fn default_channels(is_uplink: bool) -> usize;
+    /// For a dynamic channel plan, get the 800 or 900 channel list for the region.
     fn channel_from_list(channel_id: usize) -> Result<DynamicChannel, Error>;
+    /// Get the default uplink or downlink frequency based on channel index for the region.
     fn mandatory_frequency(index: usize, is_uplink: bool) -> u32;
+    /// Get the default uplink data rate based on channel index for the region.
     fn mandatory_ul_data_rate_range(index: usize) -> (DR, DR);
+    /// Get the uplink data rate range.
     fn ul_data_rate_range() -> (DR, DR);
+    /// Get the default data rate for the region.
     fn default_data_rate() -> DR;
+    /// Override the uplink data rate based on region, frame type (join or data), and frequency.
     fn override_ul_data_rate_if_necessary(dr: DR, frame: Frame, ul_frequency: u32) -> DR;
+    /// Get the default coding rate for the region.
     fn default_coding_rate() -> CodingRate;
+    /// Get the default RX2 frequency for the region.
     fn default_rx2_frequency() -> u32;
+    /// Get the default RX2 data rate for the region.
     fn default_rx2_data_rate() -> DR;
+    /// Get the maximum EIRP for the region.
     fn max_eirp() -> u8;
+    /// Get the minimum frequency for the region.
     fn min_frequency() -> u32;
+    /// Get the maximum frequency for the region.
     fn max_frequency() -> u32;
+    /// Convert the data rate to spreading factor and bandwidth for the region.
     fn convert_data_rate(dr: DR) -> Result<Datarate, Error>;
+    /// For the region, determine the RX1 data rate based on the uplink data rate and data rate offset.
     fn get_rx1_dr(ul_dr: DR, rx1_dr_offset: u8) -> Result<DR, Error>;
+    /// Does the region support TXParamSetupReq packet processing?
     fn supports_tx_param_setup() -> bool;
+    /// Based on the LinkADRReq packet and the region, modify the configured transmission power.
     fn modify_dbm(tx_power: u8, cur_dbm: Option<u8>, max_eirp: u8) -> Result<Option<u8>, Error>;
-
+    /// Get the default RX delay for the region.
     fn default_rx_delay() -> u16 {
         1000
     }
+    /// Get the default RX1 data rate offset for the region.
     fn default_rx1_data_rate_offset() -> u8;
+    /// Get the default delay from now before opening the RX1 window for a join accept packet from a network server.
     fn default_join_accept_delay1() -> u16 {
         5000
     }
+    /// Get the default delay from now before opening the RX2 window for a join accept packet from a network server.
     fn default_join_accept_delay2() -> u16 {
         Self::default_join_accept_delay1() + 1000
     }
+    /// Get the default maximum frame count gap for the region.
     fn default_max_fcnt_gap() -> u32 {
         16384
     }
+    /// Get the default ADR acknowledgement limit for the region.
     fn default_adr_ack_limit() -> usize {
         64
     }
+    /// Get the default ADR acknowledgement delay for the region.
     fn default_adr_ack_delay() -> u8 {
         32
     }

--- a/src/mac/region/mod.rs
+++ b/src/mac/region/mod.rs
@@ -31,6 +31,8 @@ where
         Self::Region(value)
     }
 }
+
+/// Specification of functionality to describe regional characteristics.
 pub trait Region {
     fn default_channels(is_uplink: bool) -> usize;
     fn channel_from_list(channel_id: usize) -> Result<DynamicChannel, Error>;

--- a/src/mac/region/mod.rs
+++ b/src/mac/region/mod.rs
@@ -1,3 +1,5 @@
+//! Specification of functionality implemented for each supported LoRaWAN region.
+
 use crate::device::radio::types::{CodingRate, Datarate};
 use crate::device::Device;
 
@@ -8,6 +10,7 @@ pub mod channel_plan;
 
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[allow(missing_docs)]
 pub enum Error {
     InvalidTxPower,
     InvalidChannelIndex,

--- a/src/mac/region/us915/mod.rs
+++ b/src/mac/region/us915/mod.rs
@@ -1,3 +1,5 @@
+//! Processing for the US915 region, which uses a fixed channel plan.
+
 use super::channel_plan::dynamic::DynamicChannel;
 use super::Error;
 use crate::device::radio::types::{Bandwidth, CodingRate, Datarate, SpreadingFactor};
@@ -158,7 +160,7 @@ impl crate::mac::Region for US915 {
             DR::_2 => Ok(dl_dr_matrix[2][rx1_dr_offset as usize]),
             DR::_3 => Ok(dl_dr_matrix[3][rx1_dr_offset as usize]),
             DR::_4 => Ok(dl_dr_matrix[4][rx1_dr_offset as usize]),
-            _ => return Err(super::Error::UnsupportedRx1DROffset(ul_dr, rx1_dr_offset)),
+            _ => Err(super::Error::UnsupportedRx1DROffset(ul_dr, rx1_dr_offset)),
         }
     }
 

--- a/src/mac/region/us915/mod.rs
+++ b/src/mac/region/us915/mod.rs
@@ -5,6 +5,7 @@ use super::Error;
 use crate::device::radio::types::{Bandwidth, CodingRate, Datarate, SpreadingFactor};
 use crate::mac::types::{Frame, DR};
 
+/// Specific processing for the US915 region.
 pub struct US915;
 
 impl crate::mac::Region for US915 {

--- a/src/mac/types.rs
+++ b/src/mac/types.rs
@@ -1,3 +1,5 @@
+//! Properties used in LoRaWAN MAC processing.
+
 use crate::encoding::keys::{CryptoFactory, AES128};
 use crate::encoding::parser::{DecryptedJoinAcceptPayload, DevAddr, DevNonce};
 
@@ -52,12 +54,7 @@ pub struct Credentials {
 }
 impl Credentials {
     pub fn new(app_eui: [u8; 8], dev_eui: [u8; 8], app_key: [u8; 16]) -> Self {
-        Self {
-            app_eui,
-            dev_eui,
-            app_key: AES128(app_key),
-            dev_nonce: 0,
-        }
+        Self { app_eui, dev_eui, app_key: AES128(app_key), dev_nonce: 0 }
     }
     pub fn incr_dev_nonce(&mut self) {
         self.dev_nonce += 1;
@@ -91,13 +88,7 @@ impl Session {
     }
 
     pub fn new(newskey: AES128, appskey: AES128, devaddr: DevAddr<[u8; 4]>) -> Self {
-        Self {
-            newskey,
-            appskey,
-            devaddr,
-            fcnt_up: 0,
-            fcnt_down: 0,
-        }
+        Self { newskey, appskey, devaddr, fcnt_up: 0, fcnt_down: 0 }
     }
 
     pub fn newskey(&self) -> &AES128 {
@@ -160,6 +151,7 @@ impl From<Storable> for &[u8] {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[allow(missing_docs)]
 #[repr(u8)]
 pub enum DR {
     _0 = 0,
@@ -213,6 +205,7 @@ impl TryFrom<u8> for DR {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(missing_docs)]
 pub enum MType {
     JoinRequest,
     JoinAccept,
@@ -224,11 +217,13 @@ pub enum MType {
     Proprietary,
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(missing_docs)]
 pub enum Frame {
     Join,
     Data,
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(missing_docs)]
 pub enum Window {
     _1,
     _2,

--- a/src/mac/types.rs
+++ b/src/mac/types.rs
@@ -16,6 +16,7 @@ impl RxWindows {
     }
 }
 
+/// Basic send/receive properties.
 #[derive(Debug, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Configuration {
@@ -44,6 +45,7 @@ impl Default for Configuration {
     }
 }
 
+/// Identification properties used to enable communication with a netwrk server.
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Credentials {
@@ -61,6 +63,7 @@ impl Credentials {
     }
 }
 
+/// Properties maintained during a session with a network server.
 pub struct Session {
     pub(crate) newskey: AES128,
     pub(crate) appskey: AES128,
@@ -116,6 +119,8 @@ impl Session {
     }
 }
 
+/// Basic send/receive properties persisted in non-volatile storage for
+/// continuity across power-on cycles.
 #[derive(Debug, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Storable {

--- a/src/mac/types.rs
+++ b/src/mac/types.rs
@@ -45,7 +45,7 @@ impl Default for Configuration {
     }
 }
 
-/// Identification properties used to enable communication with a netwrk server.
+/// Identification properties used to enable communication with a network server.
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Credentials {
@@ -55,9 +55,12 @@ pub struct Credentials {
     pub(crate) dev_nonce: u16,
 }
 impl Credentials {
+    /// Creation.
     pub fn new(app_eui: [u8; 8], dev_eui: [u8; 8], app_key: [u8; 16]) -> Self {
         Self { app_eui, dev_eui, app_key: AES128(app_key), dev_nonce: 0 }
     }
+
+    /// Increment the nonce associated with a join request.
     pub fn incr_dev_nonce(&mut self) {
         self.dev_nonce += 1;
     }
@@ -72,6 +75,7 @@ pub struct Session {
     pub(crate) fcnt_down: u32,
 }
 impl Session {
+    /// Creation.
     pub fn derive_new<T: AsRef<[u8]> + AsMut<[u8]>, F: CryptoFactory>(
         decrypt: &DecryptedJoinAcceptPayload<T, F>,
         devnonce: DevNonce<[u8; 2]>,
@@ -90,30 +94,37 @@ impl Session {
         )
     }
 
+    /// Creation.
     pub fn new(newskey: AES128, appskey: AES128, devaddr: DevAddr<[u8; 4]>) -> Self {
         Self { newskey, appskey, devaddr, fcnt_up: 0, fcnt_down: 0 }
     }
 
+    /// Get the network session key.
     pub fn newskey(&self) -> &AES128 {
         &self.newskey
     }
 
+    /// Get the application session key.
     pub fn appskey(&self) -> &AES128 {
         &self.appskey
     }
 
+    /// Get the device address.
     pub fn devaddr(&self) -> &DevAddr<[u8; 4]> {
         &self.devaddr
     }
 
+    /// Get the uplink frame count.
     pub fn fcnt_up(&self) -> u32 {
         self.fcnt_up
     }
 
+    /// Increment the uplink frame count.
     pub fn fcnt_up_increment(&mut self) {
         self.fcnt_up += 1;
     }
 
+    /// Has the uplink frame count reached or exceeded the limit?
     pub fn is_expired(&self) -> bool {
         self.fcnt_up() >= 0xFFFF
     }
@@ -178,6 +189,7 @@ pub enum DR {
 }
 
 impl DR {
+    /// Is this DR within range?
     pub fn in_range(&self, range: (DR, DR)) -> bool {
         (range.0 as u8 <= *self as u8) && (*self as u8 <= range.1 as u8)
     }


### PR DESCRIPTION
Within a local lorawan repo:

cargo doc --open

now returns no warnings about missing documentation.

A more complete README will be done through a separate PR.  I thought it best to get this PR in the pipeline so it can be merged to main before further implementation is done, to avoid merge collisions since this PR touches many files.