### PR TITLE
add serde to storable for easy serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,15 @@ generic-array = "0.14.2"
 aes = { version = "0.8.2", optional = true }
 cmac = { version = "0.7.2", optional = true }
 futures = { version = "0.3.17", default-features = false }
-defmt = { version = "0.3.0", optional = true }
+defmt = { version = "0.3", optional = true }
 lora-phy = { version = "2" }
+serde = { version = "1.0", default-features = false, features = ["derive"], optional = true}
 
 [dev-dependencies]
 mockall = "0.11.4"
 
 [features]
-default = ["default-crypto", "defmt"]
+default = ["default-crypto", "defmt","serde"]
 defmt = ["dep:defmt"]
 default-crypto = ["aes", "cmac"]
+serde = ["dep:serde"]

--- a/src/device/non_volatile_store.rs
+++ b/src/device/non_volatile_store.rs
@@ -13,8 +13,8 @@ pub trait NonVolatileStore {
     #[cfg(not(feature = "defmt"))]
     type Error: Debug;
 
-    /// Persist data which can be converted to a u8 array.
+    /// Save storable to persistent store.
     fn save(&mut self, storable: Storable) -> Result<(), Self::Error>;
-    /// Retrieve data from persistence which can be converted from a u8 array.
+    /// Load storable from peristent store.
     fn load(&mut self) -> Result<Storable, Self::Error>;
 }

--- a/src/device/non_volatile_store.rs
+++ b/src/device/non_volatile_store.rs
@@ -2,6 +2,8 @@
 
 use core::fmt::Debug;
 
+use crate::mac::types::Storable;
+
 /// Specification of the functionality required of the caller for persistence.
 pub trait NonVolatileStore {
     /// Possible result error.
@@ -12,11 +14,7 @@ pub trait NonVolatileStore {
     type Error: Debug;
 
     /// Persist data which can be converted to a u8 array.
-    fn save<'a, T>(&mut self, item: T) -> Result<(), Self::Error>
-    where
-        T: Sized + Into<&'a [u8]>;
+    fn save(&mut self, storable: Storable) -> Result<(), Self::Error>;
     /// Retrieve data from persistence which can be converted from a u8 array.
-    fn load<'a, T>(&'a mut self) -> Result<T, Self::Error>
-    where
-        T: Sized + TryFrom<&'a [u8]>;
+    fn load(&mut self) -> Result<Storable, Self::Error>;
 }

--- a/src/mac/types.rs
+++ b/src/mac/types.rs
@@ -134,39 +134,19 @@ impl Session {
 /// continuity across power-on cycles.
 #[derive(Debug, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[allow(missing_docs)]
 pub struct Storable {
-    pub(crate) rx1_data_rate_offset: Option<u8>,
-    pub(crate) rx_delay: Option<u8>,
-    pub(crate) rx2_data_rate: Option<DR>,
-    pub(crate) rx2_frequency: Option<u32>,
-    pub(crate) dev_nonce: u16,
-}
-impl TryFrom<&[u8]> for Storable {
-    type Error = ();
-
-    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        if bytes.len() != ::core::mem::size_of::<Self>() || bytes[0] == 0xff {
-            Err(())
-        } else {
-            let mut buf: [u8; ::core::mem::size_of::<Self>()] = [0; ::core::mem::size_of::<Self>()];
-            buf.copy_from_slice(bytes);
-            Ok(unsafe { core::mem::transmute::<[u8; ::core::mem::size_of::<Self>()], Self>(buf) })
-        }
-    }
-}
-impl From<Storable> for &[u8] {
-    fn from(storable: Storable) -> Self {
-        unsafe {
-            ::core::slice::from_raw_parts(
-                (&storable as *const Storable) as *const u8,
-                ::core::mem::size_of::<Storable>(),
-            )
-        }
-    }
+    pub rx1_data_rate_offset: Option<u8>,
+    pub rx_delay: Option<u8>,
+    pub rx2_data_rate: Option<DR>,
+    pub rx2_frequency: Option<u32>,
+    pub dev_nonce: u16,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[allow(missing_docs)]
 #[repr(u8)]
 pub enum DR {


### PR DESCRIPTION
The old serialization was too naive and brought problems with alignment. This change adds serde behind a feature and removes the unsafe serialization code.