### PR TITLE
Simplify Device trait structure

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,5 @@
   "rust-analyzer.procMacro.attributes.enable": false,
   "rust-analyzer.cargo.features": "all",
   "rust-analyzer.check.features": "all",
-  "rust-analyzer.check.command": "clippy"
+  "rust-analyzer.check.command": "clippy",
 }

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -74,7 +74,7 @@ pub trait Device {
         &mut self,
         configuration: &Configuration,
         credentials: &Credentials,
-    ) -> Result<(), <<Self as Device>::NonVolatileStore as NonVolatileStore>::Error> {
+    ) -> Result<(), <Self::NonVolatileStore as NonVolatileStore>::Error> {
         let storable = Storable {
             rx1_data_rate_offset: configuration.rx1_data_rate_offset,
             rx_delay: configuration.rx_delay,
@@ -102,10 +102,8 @@ pub trait Device {
         app_eui: [u8; 8],
         dev_eui: [u8; 8],
         app_key: [u8; 16],
-    ) -> Result<
-        (Configuration, Credentials),
-        <<Self as Device>::NonVolatileStore as NonVolatileStore>::Error,
-    > {
+    ) -> Result<(Configuration, Credentials), <Self::NonVolatileStore as NonVolatileStore>::Error>
+    {
         let storable: Storable = non_volatile_store.load()?;
         let configuration = Configuration {
             rx1_data_rate_offset: storable.rx1_data_rate_offset,

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -10,7 +10,7 @@ use radio::Radio;
 use rng::Rng;
 use timer::Timer;
 
-use crate::mac::types::DR;
+use crate::mac::types::{Configuration, Credentials, Storable, DR};
 
 use self::non_volatile_store::NonVolatileStore;
 
@@ -69,14 +69,59 @@ pub trait Device {
     fn adaptive_data_rate_enabled(&self) -> bool {
         true
     }
+    /// Persist information required to maintain communication with a network server through end device power cycles.
+    fn persist_to_non_volatile(
+        &mut self,
+        configuration: &Configuration,
+        credentials: &Credentials,
+    ) -> Result<(), <<Self as Device>::NonVolatileStore as NonVolatileStore>::Error> {
+        let storable = Storable {
+            rx1_data_rate_offset: configuration.rx1_data_rate_offset,
+            rx_delay: configuration.rx_delay,
+            rx2_data_rate: configuration.rx2_data_rate,
+            rx2_frequency: configuration.rx2_frequency,
+            dev_nonce: credentials.dev_nonce,
+        };
+        if let Ok(old_storable) = self.non_volatile_store().load() {
+            if storable != old_storable {
+                trace!("overwrite {} {}", old_storable, storable);
+                self.non_volatile_store().save(storable)?;
+            } else {
+                trace!("nothing changed {}", storable);
+            }
+        } else {
+            trace!("Save fresh {}", storable);
+            self.non_volatile_store().save(storable)?;
+        }
+        Ok(())
+    }
+
+    /// Restore information required to maintain end device communication with a network server.
+    fn hydrate_from_non_volatile(
+        non_volatile_store: &mut Self::NonVolatileStore,
+        app_eui: [u8; 8],
+        dev_eui: [u8; 8],
+        app_key: [u8; 16],
+    ) -> Result<
+        (Configuration, Credentials),
+        <<Self as Device>::NonVolatileStore as NonVolatileStore>::Error,
+    > {
+        let storable: Storable = non_volatile_store.load()?;
+        let configuration = Configuration {
+            rx1_data_rate_offset: storable.rx1_data_rate_offset,
+            rx_delay: storable.rx_delay,
+            rx2_data_rate: storable.rx2_data_rate,
+            rx2_frequency: storable.rx2_frequency,
+            ..Default::default()
+        };
+        let mut credentials = Credentials::new(app_eui, dev_eui, app_key);
+        credentials.dev_nonce = storable.dev_nonce;
+        Ok((configuration, credentials))
+    }
     /// Create a DevStatusAns response to a network server specifying battery level as directed by the caller.
     fn battery_level(&self) -> Option<f32> {
         None
     }
-}
-
-/// Specification of end device-specific limits provided by the caller.
-pub trait DeviceSpecs {
     /// Get the minimum frequency supported by a device as indicated by the caller.
     fn min_frequency() -> Option<u32> {
         None

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -108,14 +108,14 @@ where
 
     /// Get the minimum frequency, perhaps unique to the given end device.
     fn min_frequency() -> u32 {
-        match <D as Device>::min_frequency() {
+        match D::min_frequency() {
             Some(device_min_frequency) => max(device_min_frequency, R::min_frequency()),
             None => R::min_frequency(),
         }
     }
     /// Get the maximum frequency, perhaps unique to the given end device.
     fn max_frequency() -> u32 {
-        match <D as Device>::max_frequency() {
+        match D::max_frequency() {
             Some(device_max_frequency) => min(device_max_frequency, R::max_frequency()),
             None => R::max_frequency(),
         }
@@ -313,10 +313,7 @@ where
         device: &mut D,
         rx_quality: RxQuality,
         cmds: MacCommandIterator<'_, DownlinkMacCommand<'_>>,
-    ) -> Result<(), crate::Error<D>>
-    where
-        D: Device,
-    {
+    ) -> Result<(), crate::Error<D>> {
         let mut channel_mask = self.channel_plan.get_channel_mask();
         let mut cmd_iter = cmds.into_iter().peekable();
         while let Some(cmd) = cmd_iter.next() {
@@ -650,10 +647,7 @@ where
         &'m mut self,
         device: &'m mut D,
         radio_buffer: &'m mut RadioBuffer<256>,
-    ) -> Result<(), crate::Error<D>>
-    where
-        D: Device,
-    {
+    ) -> Result<(), crate::Error<D>> {
         self.credentials.incr_dev_nonce();
         device
             .persist_to_non_volatile(&self.configuration, &self.credentials)

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -164,7 +164,7 @@ where
         (rx1_data_rate_offset_ack, rx2_data_rate_ack)
     }
 
-    /// Get the maximum EIRP for the ednd device.
+    /// Get the maximum EIRP for the end device.
     fn max_eirp() -> u8 {
         min(R::max_eirp(), D::max_eirp())
     }

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -277,10 +277,7 @@ where
         window: &Window,
         data_rate: DR,
         channel: &C::Channel,
-    ) -> Result<RfConfig, crate::Error<D>>
-    where
-        D: Device,
-    {
+    ) -> Result<RfConfig, crate::Error<D>> {
         let data_rate = match window {
             Window::_1 => self.rx1_data_rate(data_rate),
             Window::_2 => self.rx2_data_rate(frame),
@@ -497,10 +494,7 @@ where
         radio_buffer: &'m mut RadioBuffer<256>,
         data_rate: DR,
         channel: &C::Channel,
-    ) -> Result<Option<(usize, RxQuality)>, crate::Error<D>>
-    where
-        D: Device,
-    {
+    ) -> Result<Option<(usize, RxQuality)>, crate::Error<D>> {
         let windows = self.get_rx_windows(frame);
 
         let open_rx1_fut = device
@@ -597,10 +591,7 @@ where
         device: &mut D,
         radio_buffer: &mut RadioBuffer<256>,
         frame: Frame,
-    ) -> Result<Option<(usize, RxQuality)>, crate::Error<D>>
-    where
-        D: Device,
-    {
+    ) -> Result<Option<(usize, RxQuality)>, crate::Error<D>> {
         let tx_buffer = radio_buffer.clone();
 
         for _ in 0..self.configuration.number_of_transmissions {
@@ -730,10 +721,7 @@ where
         fport: u8,
         confirmed: bool,
         rx: Option<&mut [u8]>,
-    ) -> Result<Option<(usize, RxQuality)>, crate::Error<D>>
-    where
-        D: Device,
-    {
+    ) -> Result<Option<(usize, RxQuality)>, crate::Error<D>> {
         if let Some(ref mut session_data) = self.session {
             if !session_data.is_expired() {
                 session_data.fcnt_up_increment();


### PR DESCRIPTION
remove DeviceSpecs and MacDevice

This removes complexity left over from when there was different Mac modules per version