### PR TITLE
Miscellaneous enhancements and a fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 name = "lorawan"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
+repository = "https://github.com/lucasgranberg/lorawan"
+categories = ["embedded", "no-std", "asynchronous"]
+keywords = ["lorawan", "lora", "radio", "iot", "semtech"]
+description = "Provides end device support for LoRaWAN revision 1.0.4."
 
 [lib]
 test = true

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -147,4 +147,10 @@ pub trait Device {
     fn max_data_rate() -> Option<DR> {
         None
     }
+    /// Get the preferred channel block index for join requests as indicated by the caller.
+    /// For both dynamic and fixed plans, there are a maximum of 80 channels: 10 channel blocks
+    /// of 8 channels each.  Therefore, valid indexes are 0 through 9.
+    fn preferred_join_channel_block_index() -> usize {
+        0
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ pub(crate) mod tests {
     use crate::device::timer::Timer;
     use crate::mac::types::Storable;
 
+    #[derive(Debug, PartialEq, defmt::Format)]
     pub(crate) struct RadioMock {}
     impl Radio for RadioMock {
         type Error = RadioError;
@@ -68,6 +69,7 @@ pub(crate) mod tests {
     pub(crate) enum NonVolatileStoreError {
         Encoding,
     }
+    #[derive(Debug, PartialEq, defmt::Format)]
     pub(crate) struct NonVolatileStoreMock {}
     impl NonVolatileStore for NonVolatileStoreMock {
         type Error = NonVolatileStoreError;
@@ -81,6 +83,7 @@ pub(crate) mod tests {
         }
     }
 
+    #[derive(Debug, PartialEq, defmt::Format)]
     pub(crate) struct RngMock {}
     impl Rng for RngMock {
         type Error = Infallible;
@@ -90,6 +93,7 @@ pub(crate) mod tests {
         }
     }
 
+    #[derive(Debug, PartialEq, defmt::Format)]
     pub(crate) struct TimerMock {}
     impl Timer for TimerMock {
         type Error = Infallible;
@@ -102,6 +106,7 @@ pub(crate) mod tests {
         }
     }
 
+    #[derive(Debug, PartialEq, defmt::Format)]
     pub(crate) struct DeviceMock {
         rng: RngMock,
         radio: RadioMock,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(not(test), no_main)]
 #![feature(type_alias_impl_trait)]
+#![cfg_attr(test, feature(impl_trait_in_assoc_type))]
 #![feature(concat_idents)]
 #![feature(async_fn_in_trait)]
 #![allow(incomplete_features)]
@@ -26,4 +27,139 @@ where
     Region(region::Error),
     Mac(mac::Error),
     Encoding(encoding::Error),
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use core::convert::Infallible;
+    use core::future::Future;
+
+    use lora_phy::mod_params::RadioError;
+
+    use super::*;
+    use crate::device::non_volatile_store::NonVolatileStore;
+    use crate::device::radio::types::{RfConfig, RxQuality, TxConfig};
+    use crate::device::radio::Radio;
+    use crate::device::rng::Rng;
+    use crate::device::timer::Timer;
+    use crate::mac::types::Storable;
+
+    pub(crate) struct RadioMock {}
+    impl Radio for RadioMock {
+        type Error = RadioError;
+        async fn tx(&mut self, _config: TxConfig, _buf: &[u8]) -> Result<usize, Self::Error> {
+            Err(RadioError::TransmitTimeout)
+        }
+        async fn rx(
+            &mut self,
+            _config: RfConfig,
+            _window_in_secs: u8,
+            _rx_buf: &mut [u8],
+        ) -> Result<(usize, RxQuality), Self::Error> {
+            Err(RadioError::ReceiveTimeout)
+        }
+
+        async fn sleep(&mut self, _warm_start: bool) -> Result<(), Self::Error> {
+            Err(RadioError::TimeoutUnexpected)
+        }
+    }
+
+    #[derive(Debug, PartialEq, defmt::Format)]
+    pub(crate) enum NonVolatileStoreError {
+        Encoding,
+    }
+    pub(crate) struct NonVolatileStoreMock {}
+    impl NonVolatileStore for NonVolatileStoreMock {
+        type Error = NonVolatileStoreError;
+
+        fn save(&mut self, _storable: Storable) -> Result<(), Self::Error> {
+            Err(NonVolatileStoreError::Encoding)
+        }
+
+        fn load(&mut self) -> Result<Storable, Self::Error> {
+            Err(NonVolatileStoreError::Encoding)
+        }
+    }
+
+    pub(crate) struct RngMock {}
+    impl Rng for RngMock {
+        type Error = Infallible;
+
+        fn next_u32(&mut self) -> Result<u32, Self::Error> {
+            Ok(42u32)
+        }
+    }
+
+    pub(crate) struct TimerMock {}
+    impl Timer for TimerMock {
+        type Error = Infallible;
+        type AtFuture<'a> = impl Future<Output = ()> + 'a where Self: 'a;
+
+        fn reset(&mut self) {}
+        fn at<'a>(&self, _millis: u64) -> Result<Self::AtFuture<'a>, Self::Error> {
+            let fut = async move {};
+            Ok(fut) as Result<Self::AtFuture<'a>, Infallible>
+        }
+    }
+
+    pub(crate) struct DeviceMock {
+        rng: RngMock,
+        radio: RadioMock,
+        timer: TimerMock,
+        non_volatile_store: NonVolatileStoreMock,
+    }
+
+    impl DeviceMock {
+        #[allow(dead_code)]
+        pub(crate) fn new() -> Self {
+            Self {
+                rng: RngMock {},
+                radio: RadioMock {},
+                timer: TimerMock {},
+                non_volatile_store: NonVolatileStoreMock {},
+            }
+        }
+    }
+
+    impl Device for DeviceMock {
+        type Timer = TimerMock;
+
+        type Radio = RadioMock;
+
+        type Rng = RngMock;
+
+        type NonVolatileStore = NonVolatileStoreMock;
+
+        fn timer(&mut self) -> &mut Self::Timer {
+            &mut self.timer
+        }
+
+        fn radio(&mut self) -> &mut Self::Radio {
+            &mut self.radio
+        }
+
+        fn rng(&mut self) -> &mut Self::Rng {
+            &mut self.rng
+        }
+
+        fn non_volatile_store(&mut self) -> &mut Self::NonVolatileStore {
+            &mut self.non_volatile_store
+        }
+
+        fn max_eirp() -> u8 {
+            22
+        }
+
+        fn adaptive_data_rate_enabled(&self) -> bool {
+            true
+        }
+
+        fn handle_device_time(&mut self, _seconds: u32, _nano_seconds: u32) {}
+
+        fn handle_link_check(&mut self, _gateway_count: u8, _margin: u8) {}
+
+        fn battery_level(&self) -> Option<f32> {
+            None
+        }
+    }
 }

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -627,15 +627,7 @@ where
         let tx_buffer = radio_buffer.clone();
 
         for _ in 0..self.configuration.number_of_transmissions {
-            let mut channel_block_randoms = [0x00u32; NUM_OF_CHANNEL_BLOCKS];
-            for channel_block_random in channel_block_randoms.iter_mut().take(NUM_OF_CHANNEL_BLOCKS)
-            {
-                *channel_block_random =
-                    device.rng().next_u32().map_err(crate::device::Error::Rng)?;
-            }
-            let channels =
-                self.channel_plan.get_random_channels_from_blocks(channel_block_randoms, frame)?;
-
+            let channels = self.get_send_channels(device, frame);
             for channel in channels {
                 if let Some(chn) = channel {
                     let tx_data_rate = R::override_ul_data_rate_if_necessary(
@@ -857,5 +849,98 @@ where
         } else {
             Err(crate::Error::Mac(Error::NetworkNotJoined))
         }
+    }
+
+    fn get_send_channels<D: Device>(
+        &self,
+        device: &mut D,
+        frame: Frame,
+    ) -> [Option<<C as ChannelPlan<R>>::Channel>; NUM_OF_CHANNEL_BLOCKS] {
+        let mut channel_block_randoms = [0x00u32; NUM_OF_CHANNEL_BLOCKS];
+        for channel_block_random in channel_block_randoms.iter_mut().take(NUM_OF_CHANNEL_BLOCKS) {
+            *channel_block_random = device.rng().next_u32().unwrap_or(1);
+        }
+        let mut channels = self
+            .channel_plan
+            .get_random_channels_from_blocks(channel_block_randoms)
+            .unwrap_or([None, None, None, None, None, None, None, None, None, None]);
+
+        // Place the preferred channel block first if a join request is being
+        // executed, the index is greater than zero indicating a swap is needed, and
+        // the index is valid.
+        let swap_index = D::preferred_join_channel_block_index();
+        if (frame == Frame::Join) && (swap_index > 0) && (swap_index < NUM_OF_CHANNEL_BLOCKS) {
+            channels.swap(0, swap_index);
+        }
+        channels
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use crate::mac::region::channel_plan::dynamic::DynamicChannelPlan;
+    use crate::mac::region::channel_plan::fixed::FixedChannelPlan;
+    use crate::mac::region::eu868::EU868;
+    use crate::mac::region::us915::US915;
+    use crate::mac::Mac;
+    use crate::tests::*;
+
+    use super::types::{Credentials, Frame};
+
+    #[test]
+    fn validate_frequency() {
+        assert!(Mac::<EU868, DynamicChannelPlan<EU868>>::validate_frequency::<DeviceMock>(
+            863_000_000
+        ));
+        assert!(Mac::<EU868, DynamicChannelPlan<EU868>>::validate_frequency::<DeviceMock>(
+            870_000_000
+        ));
+        assert!(!Mac::<EU868, DynamicChannelPlan<EU868>>::validate_frequency::<DeviceMock>(
+            870_000_001
+        ));
+        assert!(Mac::<US915, FixedChannelPlan<US915>>::validate_frequency::<DeviceMock>(
+            902_000_000
+        ));
+        assert!(Mac::<US915, FixedChannelPlan<US915>>::validate_frequency::<DeviceMock>(
+            928_000_000
+        ));
+        assert!(!Mac::<US915, FixedChannelPlan<US915>>::validate_frequency::<DeviceMock>(
+            928_000_001
+        ));
+    }
+
+    #[test]
+    fn get_send_channels() {
+        let mac_eu868 = Mac::<EU868, DynamicChannelPlan<EU868>>::new(
+            Default::default(),
+            Credentials::new([0u8; 8], [0u8; 8], [0u8; 16]),
+        );
+        let channels_eu868 = mac_eu868.get_send_channels(&mut DeviceMock::new(), Frame::Join);
+        assert!(channels_eu868[0].is_some());
+        assert!(channels_eu868[1].is_none());
+        assert!(channels_eu868[2].is_none());
+        assert!(channels_eu868[3].is_none());
+        assert!(channels_eu868[4].is_none());
+        assert!(channels_eu868[5].is_none());
+        assert!(channels_eu868[6].is_none());
+        assert!(channels_eu868[7].is_none());
+        assert!(channels_eu868[8].is_none());
+        assert!(channels_eu868[9].is_none());
+
+        let mac_us915 = Mac::<US915, FixedChannelPlan<US915>>::new(
+            Default::default(),
+            Credentials::new([0u8; 8], [0u8; 8], [0u8; 16]),
+        );
+        let channels_us915 = mac_us915.get_send_channels(&mut DeviceMock::new(), Frame::Join);
+        assert!(channels_us915[0].is_some());
+        assert!(channels_us915[1].is_some());
+        assert!(channels_us915[2].is_some());
+        assert!(channels_us915[3].is_some());
+        assert!(channels_us915[4].is_some());
+        assert!(channels_us915[5].is_some());
+        assert!(channels_us915[6].is_some());
+        assert!(channels_us915[7].is_some());
+        assert!(channels_us915[8].is_some());
+        assert!(channels_us915[9].is_none());
     }
 }

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -156,8 +156,9 @@ where
     }
 
     /// Is the RX1 data rate offset within range for the given end device?
-    fn validate_rx1_data_rate_offset(rx1_dr_offset: u8) -> bool {
-        (0u8..=5u8).contains(&rx1_dr_offset)
+    fn validate_rx1_data_rate_offset<D: Device>(rx1_dr_offset: u8) -> bool {
+        R::get_rx1_dr(Self::min_data_rate::<D>(), rx1_dr_offset).is_ok()
+            && R::get_rx1_dr(Self::max_data_rate::<D>(), rx1_dr_offset).is_ok()
     }
 
     /// Is the uplink data rate within range for the given end device?
@@ -168,7 +169,7 @@ where
     /// Are the downlink data rate settings in range for the given end device?
     fn validate_dl_settings<D: Device>(dl_settings: DLSettings) -> (bool, bool) {
         let rx1_data_rate_offset_ack =
-            Self::validate_rx1_data_rate_offset(dl_settings.rx1_dr_offset());
+            Self::validate_rx1_data_rate_offset::<D>(dl_settings.rx1_dr_offset());
         let rx2_data_rate_ack = Self::validate_data_rate::<D>(dl_settings.rx2_data_rate());
         (rx1_data_rate_offset_ack, rx2_data_rate_ack)
     }

--- a/src/mac/region/channel_plan/dynamic.rs
+++ b/src/mac/region/channel_plan/dynamic.rs
@@ -126,13 +126,10 @@ where
     type Channel = DynamicChannel;
 
     // Randomly choose one valid channel (if one exists) from each channel block  The returned array is likely sparsely populated.
-    // The first block initially contains 3 valid join channels, one of which will be randomly chosen for a join request as the first block
-    // representative.  This may need to change if more valid join channels are added to the first block.
     fn get_random_channels_from_blocks(
         &self,
         channel_block_randoms: [u32; NUM_OF_CHANNEL_BLOCKS],
-        frame: Frame,
-    ) -> Result<[Option<DynamicChannel>; NUM_OF_CHANNEL_BLOCKS], Error> {
+    ) -> Result<[Option<DynamicChannel>; NUM_OF_CHANNEL_BLOCKS], crate::mac::region::Error> {
         let mut random_channels: [Option<DynamicChannel>; NUM_OF_CHANNEL_BLOCKS] =
             [None; NUM_OF_CHANNEL_BLOCKS];
 
@@ -140,20 +137,12 @@ where
             let mut count = 0usize;
             let mut available_channel_ids_in_block: [Option<usize>; NUM_OF_CHANNELS_IN_BLOCK] =
                 [None; NUM_OF_CHANNELS_IN_BLOCK];
-
-            if (i == 0) && (frame == Frame::Join) {
-                for j in 0..R::default_channels(true) {
-                    available_channel_ids_in_block[count] = Some(j);
-                    count += 1;
-                }
-            } else {
-                for j in 0..NUM_OF_CHANNELS_IN_BLOCK {
-                    let channel_index: usize = (i * NUM_OF_CHANNELS_IN_BLOCK) + j;
-                    if let Some(_channel) = &self.channels[channel_index] {
-                        if self.mask[channel_index] {
-                            available_channel_ids_in_block[count] = Some(channel_index);
-                            count += 1;
-                        }
+            for j in 0..NUM_OF_CHANNELS_IN_BLOCK {
+                let channel_index: usize = (i * NUM_OF_CHANNELS_IN_BLOCK) + j;
+                if let Some(_channel) = &self.channels[channel_index] {
+                    if self.mask[channel_index] {
+                        available_channel_ids_in_block[count] = Some(channel_index);
+                        count += 1;
                     }
                 }
             }

--- a/src/mac/region/channel_plan/fixed.rs
+++ b/src/mac/region/channel_plan/fixed.rs
@@ -69,7 +69,6 @@ where
     fn get_random_channels_from_blocks(
         &self,
         channel_block_randoms: [u32; NUM_OF_CHANNEL_BLOCKS],
-        _frame: crate::mac::types::Frame,
     ) -> Result<[Option<FixedChannel>; NUM_OF_CHANNEL_BLOCKS], crate::mac::region::Error> {
         let mut random_channels: [Option<FixedChannel>; NUM_OF_CHANNEL_BLOCKS] =
             [None; NUM_OF_CHANNEL_BLOCKS];

--- a/src/mac/region/channel_plan/mod.rs
+++ b/src/mac/region/channel_plan/mod.rs
@@ -37,12 +37,10 @@ where
     /// Dynamic or fixed channel type.
     type Channel: Channel;
 
-    /// Get an active channel randomly from each channel block based on the frame type (join or data).  The resulting
-    /// collection may be sparesely populated.
+    /// Get an active channel randomly from each channel block. The resulting collection may be sparsely populated.
     fn get_random_channels_from_blocks(
         &self,
         channel_block_randoms: [u32; NUM_OF_CHANNEL_BLOCKS],
-        frame: Frame,
     ) -> Result<[Option<Self::Channel>; NUM_OF_CHANNEL_BLOCKS], Error>;
     /// Handle a new channel request from a network server.
     fn handle_new_channel_req(&mut self, payload: NewChannelReqPayload) -> Result<(), Error>;


### PR DESCRIPTION
Fix:
- determination of DR offset validity

Enhancements
- Allow the caller to specify a preferred channel block for a join channel
- Add package documentation for crates.io
- Add a device mock and sample unit tests.

One can now run unit tests using:

cargo test

in the base lorawan folder.  In addition, CI is configured to run these unit tests (see the details under "All checks have passed").