### PR TITLE
Remove lora-phy dependency; adjust lifetime names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ aes = { version = "0.8.2", optional = true }
 cmac = { version = "0.7.2", optional = true }
 futures = { version = "0.3.17", default-features = false }
 defmt = { version = "0.3", optional = true }
-lora-phy = { version = "2" }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true}
 
 [dev-dependencies]

--- a/src/device/radio/types.rs
+++ b/src/device/radio/types.rs
@@ -1,7 +1,5 @@
 //! Types used to control communication with the LoRa physical layer.
 
-use lora_phy;
-
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone)]
 #[allow(missing_docs)]
@@ -9,17 +7,6 @@ pub enum Bandwidth {
     _125KHz,
     _250KHz,
     _500KHz,
-}
-
-/// Convert the bandwidth for use in the external lora-phy crate
-impl From<Bandwidth> for lora_phy::mod_params::Bandwidth {
-    fn from(bw: Bandwidth) -> Self {
-        match bw {
-            Bandwidth::_125KHz => lora_phy::mod_params::Bandwidth::_125KHz,
-            Bandwidth::_250KHz => lora_phy::mod_params::Bandwidth::_250KHz,
-            Bandwidth::_500KHz => lora_phy::mod_params::Bandwidth::_500KHz,
-        }
-    }
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -34,20 +21,6 @@ pub enum SpreadingFactor {
     _12,
 }
 
-/// Convert the spreading factor for use in the external lora-phy crate
-impl From<SpreadingFactor> for lora_phy::mod_params::SpreadingFactor {
-    fn from(sf: SpreadingFactor) -> Self {
-        match sf {
-            SpreadingFactor::_7 => lora_phy::mod_params::SpreadingFactor::_7,
-            SpreadingFactor::_8 => lora_phy::mod_params::SpreadingFactor::_8,
-            SpreadingFactor::_9 => lora_phy::mod_params::SpreadingFactor::_9,
-            SpreadingFactor::_10 => lora_phy::mod_params::SpreadingFactor::_10,
-            SpreadingFactor::_11 => lora_phy::mod_params::SpreadingFactor::_11,
-            SpreadingFactor::_12 => lora_phy::mod_params::SpreadingFactor::_12,
-        }
-    }
-}
-
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone)]
 #[allow(missing_docs)]
@@ -56,18 +29,6 @@ pub enum CodingRate {
     _4_6,
     _4_7,
     _4_8,
-}
-
-/// Convert the coding rate for use in the external lora-phy crate
-impl From<CodingRate> for lora_phy::mod_params::CodingRate {
-    fn from(cr: CodingRate) -> Self {
-        match cr {
-            CodingRate::_4_5 => lora_phy::mod_params::CodingRate::_4_5,
-            CodingRate::_4_6 => lora_phy::mod_params::CodingRate::_4_6,
-            CodingRate::_4_7 => lora_phy::mod_params::CodingRate::_4_7,
-            CodingRate::_4_8 => lora_phy::mod_params::CodingRate::_4_8,
-        }
-    }
 }
 
 /// LoRaWAN radio signal configuration.

--- a/src/device/timer.rs
+++ b/src/device/timer.rs
@@ -6,9 +6,9 @@ use core::{fmt::Debug, future::Future};
 /// between RX windows.
 pub trait Timer: Sized {
     /// Notification of reaching a time point.
-    type AtFuture<'m>: Future<Output = ()> + 'm
+    type AtFuture<'a>: Future<Output = ()> + 'a
     where
-        Self: 'm;
+        Self: 'a;
     /// Possible result error.
     #[cfg(feature = "defmt")]
     type Error: Debug + defmt::Format;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,6 @@ pub(crate) mod tests {
     use core::convert::Infallible;
     use core::future::Future;
 
-    use lora_phy::mod_params::RadioError;
-
     use super::*;
     use crate::device::non_volatile_store::NonVolatileStore;
     use crate::device::radio::types::{RfConfig, RxQuality, TxConfig};
@@ -47,9 +45,9 @@ pub(crate) mod tests {
     #[derive(Debug, PartialEq, defmt::Format)]
     pub(crate) struct RadioMock {}
     impl Radio for RadioMock {
-        type Error = RadioError;
+        type Error = Infallible;
         async fn tx(&mut self, _config: TxConfig, _buf: &[u8]) -> Result<usize, Self::Error> {
-            Err(RadioError::TransmitTimeout)
+            Ok(0)
         }
         async fn rx(
             &mut self,
@@ -57,11 +55,11 @@ pub(crate) mod tests {
             _window_in_secs: u8,
             _rx_buf: &mut [u8],
         ) -> Result<(usize, RxQuality), Self::Error> {
-            Err(RadioError::ReceiveTimeout)
+            Ok((0, RxQuality { rssi: 0, snr: 0 }))
         }
 
         async fn sleep(&mut self, _warm_start: bool) -> Result<(), Self::Error> {
-            Err(RadioError::TimeoutUnexpected)
+            Ok(())
         }
     }
 

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -518,11 +518,11 @@ where
         Ok(())
     }
 
-    async fn rx_with_timeout<'m, D: Device>(
+    async fn rx_with_timeout<'a, D: Device>(
         &self,
         frame: Frame,
         device: &mut D,
-        radio_buffer: &'m mut RadioBuffer<256>,
+        radio_buffer: &'a mut RadioBuffer<256>,
         data_rate: DR,
         channel: &C::Channel,
     ) -> Result<Option<(usize, RxQuality)>, crate::Error<D>> {
@@ -670,10 +670,10 @@ where
     }
 
     /// Establish a session between the end device and a network server.
-    pub async fn join<'m, D: Device>(
-        &'m mut self,
-        device: &'m mut D,
-        radio_buffer: &'m mut RadioBuffer<256>,
+    pub async fn join<'a, D: Device>(
+        &'a mut self,
+        device: &'a mut D,
+        radio_buffer: &'a mut RadioBuffer<256>,
     ) -> Result<(), crate::Error<D>> {
         self.credentials.incr_dev_nonce();
         device


### PR DESCRIPTION
Remove the dependency on lora-phy.

Use 'a for lifetime names.