### PR TITLE
Only try one channel when sending data

### DIFF
--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -652,8 +652,16 @@ where
                             radio_buffer.inc(num_read);
                             return Ok(Some((num_read, rx_quality)));
                         }
-                        Ok(None) => {}
-                        Err(_e) => {}
+                        Ok(None) => {
+                            if frame == Frame::Data {
+                                return Ok(None);
+                            }
+                        }
+                        Err(e) => {
+                            if frame == Frame::Data {
+                                return Err(e);
+                            }
+                        }
                     }
                 }
 

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -626,7 +626,7 @@ where
     ) -> Result<Option<(usize, RxQuality)>, crate::Error<D>> {
         let tx_buffer = radio_buffer.clone();
 
-        for _ in 0..self.configuration.number_of_transmissions {
+        for trans_index in 0..self.configuration.number_of_transmissions {
             let channels = self.get_send_channels(device, frame)?;
             for channel in channels {
                 if let Some(chn) = channel {
@@ -654,12 +654,20 @@ where
                         }
                         Ok(None) => {
                             if frame == Frame::Data {
-                                return Ok(None);
+                                if (trans_index + 1) >= self.configuration.number_of_transmissions {
+                                    return Ok(None);
+                                } else {
+                                    break;
+                                }
                             }
                         }
                         Err(e) => {
                             if frame == Frame::Data {
-                                return Err(e);
+                                if (trans_index + 1) >= self.configuration.number_of_transmissions {
+                                    return Err(e);
+                                } else {
+                                    break;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
For both confirmed and unconfirmed uplink data transmissions, attempt the send operation only once on a network-supported uplink channel within the send_buffer function.  Failure to receive a response to a confirmed uplink data transmission should be handled outside the send_buffer function.

This differs from join operations, which for fixed channel plans may have to attempt the join on several channels to find one that is actually supported by a network gateway.  The join accept response should include a CFList which specifies which channels can be used going forward for send data operations.